### PR TITLE
Add regression test

### DIFF
--- a/input/regression_tests/input_regression_1
+++ b/input/regression_tests/input_regression_1
@@ -1,19 +1,19 @@
 ##############################################################
-# Title: regression_test_1
-# Descriptive title: all_around_metal
+# Title : regression_test_1
+# Descriptive title : all_around_metal
 # 
-# Modules tested: Equilibrium NEGF for carbon nanotubes, 
+# Modules tested : Equilibrium NEGF for carbon nanotubes,
 # Broyden's second method, Electrostatics with EBs
 # 
-# Description: Test models a (17,0) carbon nanotube surrounded 
-# by a palladium contact. Electrostatic potential is imposed 
-# on the metal as "Gate.surf_soln_function" from 0 to 0.5 V in 
-# 2 steps. At each step the charge density on the nanotube 
-# varies until self consistency is achieved with respect to 
-# the potential. Potential at 1 V in the domain is compared.
+# Description : Test models a(17, 0) carbon nanotube surrounded
+# by a palladium contact.Electrostatic potential is imposed
+# on the metal as "Gate.surf_soln_function" from 0 to 0.5 V in
+#  2 steps.At each step the charge density on the nanotube
+# varies until self consistency is achieved with respect to
+# the potential.Potential at 1 V in the domain is compared.
 # 
-# Ref: Stewart and Francois (2006), Nanotechnology 17:4699.
-# doi:10.1088/0957-4484/17/18/029
+# Ref : Stewart and Léonard (2006), Nanotechnology 17 : 4699.
+# doi : 10.1088/0957-4484/17/18/029
 ###############################################################
 
 use_electrostatic = 1
@@ -78,7 +78,7 @@ my_constants.QD_z = GO_h + 2*R_CN + 1e-9
 
 my_constants.sigma_QD = 0.2e-9 #used for Gaussian spreading
 
-# charge density without Gaussian spreading
+#charge density without Gaussian spreading
 my_constants.R_QD = 0.2e-9
 my_constants.charge_density_QD = charge_QD / ((4./3)*pi*R_QD**3)
 
@@ -165,9 +165,11 @@ macroscopic.ghostcells_for_fields = alpha.0 epsilon.1 charge_density.1 phi.1  at
 
 macroscopic.alpha = 0.
 macroscopic.charge_density = 0.
-#macroscopic.charge_density_function = "charge_density_surr + charge_QD * (1./(sqrt(2*pi)*sigma_QD)**3)* exp(-1*( (x-QD_x)**2 + (y-QD_y)**2 + (z-QD_z)**2 ) / (2*sigma_QD**2) )"
+#macroscopic.charge_density_function = \
+    "charge_density_surr + charge_QD * (1./(sqrt(2*pi)*sigma_QD)**3)* exp(-1*( (x-QD_x)**2 + (y-QD_y)**2 + (z-QD_z)**2 ) / (2*sigma_QD**2) )"
 
-#macroscopic.epsilon_function = "epsilon_0 + (epsilon_GO - epsilon_0)    *(z >= 0.)   *(z < GO_h)"
+#macroscopic.epsilon_function = \
+    "epsilon_0 + (epsilon_GO - epsilon_0)    *(z >= 0.)   *(z < GO_h)"
 macroscopic.epsilon_function = "epsilon_0"
 macroscopic.phi = 0.
 macroscopic.atom_locations = 0.
@@ -183,7 +185,7 @@ macroscopic.atom_locations = 0.
 ####################
 
 plot.folder_name = regression_test_1
-plot.fields_to_plot = phi.1 
+plot.fields_to_plot = phi.1
 plot.write_after_init = 0
 plot.write_interval = 1
 plot.rawfield_write_interval = 1000000

--- a/input/regression_tests/input_regression_1
+++ b/input/regression_tests/input_regression_1
@@ -1,0 +1,265 @@
+##############################################################
+# Title: regression_test_1
+# Descriptive title: all_around_metal
+# 
+# Modules tested: Equilibrium NEGF for carbon nanotubes, 
+# Broyden's second method, Electrostatics with EBs
+# 
+# Description: Test models a (17,0) carbon nanotube surrounded 
+# by a palladium contact. Electrostatic potential is imposed 
+# on the metal as "Gate.surf_soln_function" from 0 to 0.5 V in 
+# 2 steps. At each step the charge density on the nanotube 
+# varies until self consistency is achieved with respect to 
+# the potential. Potential at 1 V in the domain is compared.
+# 
+# Ref: Stewart and Francois (2006), Nanotechnology 17:4699.
+# doi:10.1088/0957-4484/17/18/029
+###############################################################
+
+use_electrostatic = 1
+use_transport = 1
+amrex.the_arena_is_managed=1
+
+my_constants.m_index = 17
+my_constants.n_index = 0
+my_constants.CN_z = Lz/2.
+my_constants.CN_x = 0.
+my_constants.CN_y = 0.
+
+my_constants.GV_min = 0.
+my_constants.GV_max = 0.5
+my_constants.Nsteps =  2
+my_constants.dt = 1./(Nsteps-1)
+
+my_constants.Ef = -1.       #Palladium Contact Fermi level [eV]
+
+##################################
+##### USER DEFINED CONSTANTS #####
+##################################
+### Physical and Other Constants
+my_constants.q = 1.602e-19
+my_constants.epsilon_0 = 8.8541878128e-12
+my_constants.tiny = 1e-12
+my_constants.pi = 3.141592653589793
+
+
+### gate oxide
+my_constants.GO_w = Lx
+my_constants.GO_l = Ly
+my_constants.GO_h = CN_z - 10*dz      #smallest dimension that limits n_cell in z.
+
+my_constants.epsilon_GO = 1*epsilon_0
+
+#contact metal
+my_constants.SV =  0  #source voltage [V]
+my_constants.DV = 0. #drain voltage [V]
+my_constants.epsilon_CM = 1.7*epsilon_0 #Palladium
+
+### Carbon nanotube
+my_constants.bond_length = 0.142e-9
+my_constants.N_unitcells = 4
+my_constants.L_unitcell = 3*bond_length #0.426e-9
+
+my_constants.R_CN = bond_length*sqrt(3.*(m_index*m_index + n_index*n_index + m_index*n_index))/(2*pi)  #radius
+my_constants.CN_co_l = 2*L_unitcell
+
+my_constants.small_gap = 0.3e-9  #0.1e-9 #5*bond_length #0.355e-9, gap between nanotube and the contacts
+
+my_constants.epsilon_CN = epsilon_0 #vacuum
+
+### Quantum dot
+my_constants.charge_density_surr = 0.0 #surrounding charge density
+
+#my_constants.charge_QD = 0.
+my_constants.charge_QD = q
+my_constants.QD_x = 0.
+my_constants.QD_y = 0.
+my_constants.QD_z = GO_h + 2*R_CN + 1e-9
+
+my_constants.sigma_QD = 0.2e-9 #used for Gaussian spreading
+
+# charge density without Gaussian spreading
+my_constants.R_QD = 0.2e-9
+my_constants.charge_density_QD = charge_QD / ((4./3)*pi*R_QD**3)
+
+### Total domain dimensions
+my_constants.D_CN_unitcell = 1          #ceil(R_CN*2./L_unitcell) #2
+
+my_constants.Ly_offset_unitcells = 0
+my_constants.Lx = D_CN_unitcell*8*L_unitcell
+my_constants.Ly = (N_unitcells + Ly_offset_unitcells)*L_unitcell
+my_constants.Lz = D_CN_unitcell*8*L_unitcell
+
+my_constants.nx = 2*7*D_CN_unitcell*8  #224, dx= 0.0355 nm
+my_constants.ny = 2*7*(N_unitcells+Ly_offset_unitcells)     #28,  dy= 0.071 nm
+my_constants.nz = 2*7*D_CN_unitcell*8   #224, dz= 0.0355 nm
+
+my_constants.dx = Lx/nx
+my_constants.dy = Ly/ny
+my_constants.dz = Lz/nz
+
+my_constants.gx = 2
+my_constants.gy = 2
+my_constants.gz = 2
+
+my_constants.epsilon_domain = epsilon_0 #air
+
+##################################################
+###### TIME DEPENDENT SIMULATION PROPERTIES ######
+##################################################
+
+timestep = dt
+steps = Nsteps
+restart = 0
+restart_step = 0
+
+####################################
+###### EMBEDDED BOUNDARIES ######
+####################################
+
+domain.embedded_boundary = 1  #options: 1=true, 0=false (default)
+domain.specify_using_eb2 = 0  #options: 1=true, 0=false (default)
+
+ebgeom.objects =  Gate
+ebgeom.specify_inhomo_dir = 1
+
+Gate.geom_type      = cntfet_contact_cyl
+Gate.inner_radius   = R_CN + small_gap
+Gate.thickness      = 10*dz
+Gate.center         = CN_x CN_y CN_z
+Gate.height         = Ly + 2*dy/5
+Gate.direction      = 1
+Gate.surf_soln_parser   = 1
+Gate.surf_soln_function = "GV_min + (GV_max-GV_min) * t"
+
+#################################
+###### GEOMETRY PROPERTIES ######
+#################################
+domain.n_cell = nx ny nz
+domain.max_grid_size = nx/gx ny/gy nz/gz
+domain.blocking_factor = nx/gx ny/gy nz/gz
+
+domain.prob_lo = -Lx/2. -Ly/2.  0.
+domain.prob_hi =  Lx/2.  Ly/2.  Lz
+
+domain.is_periodic = 0 0 0
+
+domain.coord_sys = cartesian
+
+#################################
+###### BOUNDARY CONDITIONS ######
+#################################
+#boundary.hi = neu(0.) neu(0) neu(0.)
+#boundary.lo = neu(0.) neu(0) neu(0.)
+boundary.hi = neu(0.) neu neu(0.)
+boundary.lo = neu(0.) neu neu(0.)
+
+#boundary.GV_function = "GV_min + (GV_max-GV_min) * t" #V
+
+
+####################################
+###### MACROSCOPIC PROPERTIES ######
+####################################
+macroscopic.fields_to_define = alpha epsilon charge_density phi atom_locations
+macroscopic.ghostcells_for_fields = alpha.0 epsilon.1 charge_density.1 phi.1  atom_locations.0
+
+macroscopic.alpha = 0.
+macroscopic.charge_density = 0.
+#macroscopic.charge_density_function = "charge_density_surr + charge_QD * (1./(sqrt(2*pi)*sigma_QD)**3)* exp(-1*( (x-QD_x)**2 + (y-QD_y)**2 + (z-QD_z)**2 ) / (2*sigma_QD**2) )"
+
+#macroscopic.epsilon_function = "epsilon_0 + (epsilon_GO - epsilon_0)    *(z >= 0.)   *(z < GO_h)"
+macroscopic.epsilon_function = "epsilon_0"
+macroscopic.phi = 0.
+macroscopic.atom_locations = 0.
+
+#############################
+###### POST PROCESSING ######
+#############################
+
+#post_process.fields_to_process = vecField
+
+####################
+###### OUTPUT ######
+####################
+
+plot.folder_name = regression_test_1
+plot.fields_to_plot = phi.1 
+plot.write_after_init = 0
+plot.write_interval = 1
+plot.rawfield_write_interval = 1000000
+
+########################
+###### DIAGNOSTICS #####
+########################
+use_diagnostics = 0
+
+diag.specify_using_eb = 1
+diag.objects = Surf1
+Surf1.geom_type = cylinder
+Surf1.center = 0 0 CN_z
+Surf1.radius = R_CN
+Surf1.axial_direction = 1
+Surf1.theta_reference_direction = 0
+Surf1.has_fluid_inside = 0
+Surf1.fields_to_plot = phi charge_density atom_locations
+
+####################################
+###### MLMG SOLVER PROPERTIES ######
+####################################
+
+mlmg.ascalar=0
+mlmg.bscalar=1
+
+mlmg.soln   = phi
+mlmg.rhs    = charge_density
+mlmg.alpha  = alpha
+mlmg.beta   = epsilon
+
+mlmg.set_verbose=0
+mlmg.max_order=2
+mlmg.absolute_tolerance=0
+mlmg.relative_tolerance=1e-10
+
+#################
+###### NEGF #####
+#################
+
+#nanostructure names
+transport.NS_names = cnt
+transport.use_negf = 1
+transport.NS_gather_field = phi
+transport.NS_deposit_field  = charge_density
+transport.NS_initial_deposit_value  = 0.
+transport.Broyden_fraction = 1e-1
+transport.Broyden_max_norm = 1.e-6
+transport.Broyden_norm_type = absolute
+transport.selfconsistency_algorithm = broyden_second
+transport.reset_with_previous_charge_distribution = 1
+
+transport.initialize_inverse_jacobian = 0
+cnt.initialize_charge_distribution = 0
+
+cnt.initialize_charge_distribution = 0
+
+
+cnt.type = CNT
+cnt.type_id = m_index n_index     #m n
+cnt.acc = bond_length
+cnt.gamma = 2.5        #coupling strength (eV)
+cnt.num_unitcells = N_unitcells
+cnt.offset = CN_x CN_y CN_z
+cnt.rotation_angles = 0 0 0
+cnt.flag_write_charge_components = 1
+
+cnt.contact_mu_specified = 1
+cnt.contact_mu = Ef Ef
+cnt.contact_T  = 298. 298.
+
+cnt.contact_Fermi_level = Ef
+cnt.E_valence_min = -10
+cnt.E_pole_max    = 3
+cnt.eq_integration_pts = 30 30 30
+cnt.noneq_integration_pts = 100
+
+cnt.write_at_iter = 1
+#####################################


### PR DESCRIPTION
Added regression test 

Title : regression_test_1
 Descriptive title : all_around_metal

Modules tested : Equilibrium NEGF for carbon nanotubes,
Broyden's second method, Electrostatics with EBs

Description : Test models a(17, 0) carbon nanotube surrounded
by a palladium contact.Electrostatic potential is imposed
on the metal as "Gate.surf_soln_function" from 0 to 0.5 V in
2 steps.At each step the charge density on the nanotube
varies until self consistency is achieved with respect to
the potential.Potential at 1 V in the domain is compared.

Ref : Stewart and Léonard (2006), Nanotechnology 17 : 4699.
doi : 10.1088/0957-4484/17/18/029
