### PR TITLE
Accurate site id with trap charges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ Exec/*
 !Exec/GNUmakefile
 *.ipynb_checkpoints*
 *.ex
+*tmp_build_dir/
 *.png
 *.swp
-perl_runs/
 perlscripts/
+input_local/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+Exec/*
+!Exec/GNUmakefile
+*.ipynb_checkpoints*
+*.png
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 Exec/*
 !Exec/GNUmakefile
 *.ipynb_checkpoints*
+*.ex
 *.png
 *.swp
+perl_runs/
+perlscripts/

--- a/Source/Input/MacroscopicProperties/ChargeDensitySource.H
+++ b/Source/Input/MacroscopicProperties/ChargeDensitySource.H
@@ -35,6 +35,10 @@ class c_ChargeDensitySource
     {
         return m_container.Is_Occupation_Variable();
     }
+    amrex::Real Get_mixing_factor() 
+    {
+        return m_container.Get_mixing_factor();
+    }
 
     void Deposit(amrex::MultiFab *const p_rho_mf);
 

--- a/Source/Input/MacroscopicProperties/ChargeDensitySource.H
+++ b/Source/Input/MacroscopicProperties/ChargeDensitySource.H
@@ -35,10 +35,7 @@ class c_ChargeDensitySource
     {
         return m_container.Is_Occupation_Variable();
     }
-    amrex::Real Get_mixing_factor() 
-    {
-        return m_container.Get_mixing_factor();
-    }
+    amrex::Real Get_mixing_factor() { return m_container.Get_mixing_factor(); }
 
     void Deposit(amrex::MultiFab *const p_rho_mf);
 

--- a/Source/Input/MacroscopicProperties/ChargeDensitySource.cpp
+++ b/Source/Input/MacroscopicProperties/ChargeDensitySource.cpp
@@ -88,17 +88,18 @@ void c_ChargeDensitySource<ParticleContainerType>::Gather(
                            {
                                amrex::Real old_phi = p_par_potential[p];
 
-                               amrex::Real new_phi = 
+                               amrex::Real new_phi =
                                    CloudInCell::Gather_Trilinear(p_par[p].pos(),
                                                                  plo, dx, phi);
 
                                p_par_rel_diff[p] = fabs((new_phi - old_phi) /
                                                         (new_phi + old_phi));
 
-                               //if(p_par_rel_diff[p] < THRESHOLD_REL_DIFF) {
-                                   p_par_potential[p] = new_phi*MF + old_phi*(1.-MF);
+                               // if(p_par_rel_diff[p] < THRESHOLD_REL_DIFF) {
+                               p_par_potential[p] =
+                                   new_phi * MF + old_phi * (1. - MF);
                                //}
-                               //else {
+                               // else {
                                //    p_par_potential[p] = new_phi;
                                // }
                            });

--- a/Source/Input/MacroscopicProperties/ChargeDensitySource.cpp
+++ b/Source/Input/MacroscopicProperties/ChargeDensitySource.cpp
@@ -77,12 +77,30 @@ void c_ChargeDensitySource<ParticleContainerType>::Gather(
         auto &par_potential = pti.get_potential();
         auto *p_par_potential = par_potential.data();
 
+        auto &par_rel_diff = pti.get_relative_difference();
+        auto *p_par_rel_diff = par_rel_diff.data();
+
+        amrex::Real MF = Get_mixing_factor();
+        amrex::Real THRESHOLD_REL_DIFF = 1.;
+
         amrex::ParallelFor(np,
                            [=] AMREX_GPU_DEVICE(int p)
                            {
-                               p_par_potential[p] =
+                               amrex::Real old_phi = p_par_potential[p];
+
+                               amrex::Real new_phi = 
                                    CloudInCell::Gather_Trilinear(p_par[p].pos(),
                                                                  plo, dx, phi);
+
+                               p_par_rel_diff[p] = fabs((new_phi - old_phi) /
+                                                        (new_phi + old_phi));
+
+                               //if(p_par_rel_diff[p] < THRESHOLD_REL_DIFF) {
+                                   p_par_potential[p] = new_phi*MF + old_phi*(1.-MF);
+                               //}
+                               //else {
+                               //    p_par_potential[p] = new_phi;
+                               // }
                            });
     }
 }

--- a/Source/Input/MacroscopicProperties/PointChargeContainer.H
+++ b/Source/Input/MacroscopicProperties/PointChargeContainer.H
@@ -18,6 +18,7 @@ struct PointChargeAttributes
             charge_unit,
             occupation,
             potential,
+            rel_diff,
             NUM
         };
     };
@@ -64,31 +65,6 @@ class c_PointChargeContainer
     void Define(const amrex::Vector<amrex::Vector<amrex::Real>> &particles,
                 const amrex::Vector<amrex::Real> &charge_units = {},
                 const amrex::Vector<amrex::Real> &occupations = {});
-
-    // static void Set_StaticVar(amrex::Real& member_variable, amrex::Real
-    // value)
-    //{
-    //     std::lock_guard<std::mutex> lock(mtx);
-    //     member_variable = value;
-    // }
-
-    // struct GetV0 {
-    //    AMREX_GPU_HOST_DEVICE int operator() () const { return V0; }
-    //    amrex::Real V0;
-    // };
-    // static GetV0 Get_V0() { return GetV0{V0}; }
-
-    // struct GetEt {
-    //    AMREX_GPU_HOST_DEVICE int operator() () const { return Et; }
-    //    amrex::Real Et;
-    // };
-    // static GetEt Get_Et() { return GetEt{Et}; }
-    // struct GetChargeDensity {
-    //    AMREX_GPU_HOST_DEVICE int operator() () const { return charge_density;
-    //    } amrex::Real charge_density;
-    // };
-    // static GetChargeDensity Get_Charge_Density() { return
-    // GetChargeDensity{charge_density}; }
 
     amrex::Real Get_V0() { return V0; }
     amrex::Real Get_Et() { return Et; }
@@ -163,6 +139,12 @@ class c_PointChargeContainer
         {
             return this->GetStructOfArrays().GetRealData(
                 PCA::realPA::occupation);
+        }
+
+        RealVector &get_relative_difference()
+        {
+            return this->GetStructOfArrays().GetRealData(
+                PCA::realPA::rel_diff);
         }
     };
 

--- a/Source/Input/MacroscopicProperties/PointChargeContainer.H
+++ b/Source/Input/MacroscopicProperties/PointChargeContainer.H
@@ -143,8 +143,7 @@ class c_PointChargeContainer
 
         RealVector &get_relative_difference()
         {
-            return this->GetStructOfArrays().GetRealData(
-                PCA::realPA::rel_diff);
+            return this->GetStructOfArrays().GetRealData(PCA::realPA::rel_diff);
         }
     };
 

--- a/Source/Input/MacroscopicProperties/PointChargeContainer.cpp
+++ b/Source/Input/MacroscopicProperties/PointChargeContainer.cpp
@@ -1,9 +1,11 @@
+#include <limits>
+#include <iomanip>
+#include <filesystem>
+
 #include "PointChargeContainer.H"
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_Parser.H>
-
-#include <limits>
 
 #include "../../Output/Output.H"
 #include "../../Solver/Transport/Transport.H"
@@ -39,7 +41,20 @@ void c_PointChargeContainer::Define_OutputFile()
         int step = rCode.get_step();
         std::string main_output_foldername = rOutput.get_folder_name();
         std::string pc_foldername = main_output_foldername + "/point_charge";
-        CreateDirectory(pc_foldername);
+
+        //if (std::filesystem::exists(pc_foldername)) {
+        //    std::cout << "Directory exists: " << pc_foldername << "\n";
+        //} else {
+        //    try {
+        //        if (CreateDirectory(pc_foldername)) {
+        //        } else {
+        //            std::cout << "Failed to create directory, unknown reason.\n";
+        //        }
+        //    } catch (const std::filesystem::filesystem_error& e) {
+        //        std::cerr << "Filesystem error: " << e.what() << "\n";
+        //    }
+        //}a
+        UtilCreateCleanDirectory(pc_foldername, false);
         pc_stepwise_filename = pc_foldername + "/total_charge_vs_step.dat";
         outfile_pc_step.open(pc_stepwise_filename.c_str());
         outfile_pc_step << "'step', ";
@@ -62,8 +77,8 @@ void c_PointChargeContainer::Write_OutputFile()
         outfile_pc_step << std::setw(10) << step;
 #ifdef USE_TRANSPORT
         auto &rTransport = rCode.get_TransportSolver();
-        outfile_pc_step << std::setw(10) << rTransport.get_Vds()
-                        << std::setw(10) << rTransport.get_Vgs()
+        outfile_pc_step << std::setw(12) << rTransport.get_Vds()
+                        << std::setw(12) << rTransport.get_Vgs()
                         << std::setw(10) << rTransport.get_Broyden_Step() - 1;
 #endif
         outfile_pc_step << std::setw(15) << Get_total_charge() << std::setw(15)
@@ -111,7 +126,11 @@ void c_PointChargeContainer::Check_PositionBounds(
         }
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             GeomUtils::Is_ID_Within_Bounds(ID, minID, maxID) == true,
-            "Point charge " + std::to_string(s) + " is out of bounds.");
+            "Point charge " + std::to_string(s) + " is out of bounds. ID: [" 
+            + std::to_string(ID[0]) + ", "
+            + std::to_string(ID[1]) + ", "
+            + std::to_string(ID[2]) + "] "
+            );
     }
 }
 
@@ -122,23 +141,23 @@ void c_PointChargeContainer::Read_PointCharges()
     amrex::Vector<amrex::Real> vec_offset(AMREX_SPACEDIM, 0.0);
     queryArrWithParser(pp_main, "offset", vec_offset, 0, AMREX_SPACEDIM);
 
-    amrex::Print() << "pc.offset: ";
-    for (const auto &v : vec_offset) amrex::Print() << v << " ";
+    amrex::Print() << "pc.offset / (nm): ";
+    for (const auto &v : vec_offset) amrex::Print() << v*1e9 << " ";
     amrex::Print() << "\n";
 
     amrex::Vector<amrex::Real> vec_scaling(AMREX_SPACEDIM, 1.0);
     queryArrWithParser(pp_main, "scaling", vec_scaling, 0, AMREX_SPACEDIM);
 
-    amrex::Print() << "pc.scaling: ";
-    for (const auto &v : vec_scaling) amrex::Print() << v << " ";
+    amrex::Print() << "pc.scaling / (nm): ";
+    for (const auto &v : vec_scaling) amrex::Print() << v*1e9 << " ";
     amrex::Print() << "\n";
 
     amrex::Vector<amrex::Real> vec_max_bound(AMREX_SPACEDIM, 1.0);
-    amrex::Print() << "point charge max bound: ";
+    amrex::Print() << "max bound / (nm): ";
     for (int d = 0; d < AMREX_SPACEDIM; ++d)
     {
         vec_max_bound[d] = vec_offset[d] + vec_scaling[d];
-        amrex::Print() << vec_max_bound[d] << " ";
+        amrex::Print() << vec_max_bound[d]*1e9 << " ";
     }
     amrex::Print() << "\n";
 
@@ -255,6 +274,7 @@ void c_PointChargeContainer::Define(
             real_attribs[PCA::realPA::charge_unit] = charge_units[p];
             real_attribs[PCA::realPA::occupation] = occupations[p];
             real_attribs[PCA::realPA::potential] = 0.0;
+            real_attribs[PCA::realPA::rel_diff] = std::numeric_limits<double>::max(); 
 
             std::pair<int, int> key{0, 0};  // {grid_index, tile_index}
             int lev = 0;
@@ -265,19 +285,19 @@ void c_PointChargeContainer::Define(
             particle_tile.push_back_real(real_attribs);
 
             // Print the details of the newly added particle
-            amrex::Print() << "Defined particle ID: " << new_particle.id()
-                           << ", Position: (";
+            amrex::Print() << std::left << "ID: " << std::setw(8) << new_particle.id()
+                           << ", Pos/(nm): (";
             for (int j = 0; j < AMREX_SPACEDIM; ++j)
             {
-                amrex::Print() << new_particle.pos(j);
+                amrex::Print() << std::setw(12) << std::setprecision(8) << new_particle.pos(j) * 1e9;
                 if (j < AMREX_SPACEDIM - 1)
                 {
                     amrex::Print() << ", ";
                 }
             }
-            amrex::Print() << "), charge_unit: " << charge_units[p]
-                           << ", occupation: " << occupations[p]
-                           << ", potential: 0."
+            amrex::Print() << ")"
+                           << ", q: " << std::setw(10) << charge_units[p]
+                           << ", occup.: " << std::setw(10) << occupations[p]
                            << "\n";
         }
     }
@@ -292,8 +312,8 @@ void c_PointChargeContainer::Print_Container(bool print_positions)
 {
     int lev = 0;
     Vector<int> particle_ids;
-    Vector<amrex::Real> charge_units, occupations, potentials, pos_x, pos_y,
-        pos_z;
+    Vector<amrex::Real> charge_units, occupations, potentials, rel_diff,
+        pos_x, pos_y, pos_z;
 
     for (c_PointChargeContainer::ParIter pti(*this, lev); pti.isValid(); ++pti)
     {
@@ -308,6 +328,7 @@ void c_PointChargeContainer::Print_Container(bool print_positions)
             charge_units.push_back(soa_real[PCA::realPA::charge_unit][p]);
             occupations.push_back(soa_real[PCA::realPA::occupation][p]);
             potentials.push_back(soa_real[PCA::realPA::potential][p]);
+            rel_diff.push_back(soa_real[PCA::realPA::rel_diff][p]);
             if (print_positions)
             {
                 pos_x.push_back(p_par[p].pos(0));
@@ -340,8 +361,8 @@ void c_PointChargeContainer::Print_Container(bool print_positions)
 
     // allocate global vectors
     Vector<int> all_particle_ids;
-    Vector<amrex::Real> all_charge_units, all_occupations, all_potentials,
-        all_pos_x, all_pos_y, all_pos_z;
+    Vector<amrex::Real> all_charge_units, all_occupations, all_potentials, 
+        all_rel_diff, all_pos_x, all_pos_y, all_pos_z;
 
     if (ParallelDescriptor::IOProcessor())
     {
@@ -349,6 +370,7 @@ void c_PointChargeContainer::Print_Container(bool print_positions)
         all_charge_units.resize(total_particles);
         all_occupations.resize(total_particles);
         all_potentials.resize(total_particles);
+        all_rel_diff.resize(total_particles);
 
         if (print_positions)
         {
@@ -373,6 +395,9 @@ void c_PointChargeContainer::Print_Container(bool print_positions)
     ParallelDescriptor::Gatherv(potentials.data(), local_num_particles,
                                 all_potentials.data(), recvcounts, displs,
                                 ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Gatherv(rel_diff.data(), local_num_particles,
+                                all_rel_diff.data(), recvcounts, displs,
+                                ParallelDescriptor::IOProcessorNumber());
 
     if (print_positions)
     {
@@ -393,6 +418,7 @@ void c_PointChargeContainer::Print_Container(bool print_positions)
     // Printing at root process and computing total charge
     total_charge = 0.;
     total_charge_units = 0;
+    amrex::Real THRESHOLD_REL_DIFF_TO_PRINT = 1.e-5;
     if (ParallelDescriptor::IOProcessor())
     {
         amrex::Print() << "Point Charges: \n";
@@ -400,26 +426,32 @@ void c_PointChargeContainer::Print_Container(bool print_positions)
         amrex::Print() << "number of charges: " << np << "\n";
         for (int p = 0; p < np; ++p)
         {
-            amrex::Print() << "ID: " << all_particle_ids[p]
-                           << ", charge_unit: " << all_charge_units[p]
-                           << ", occupation: " << all_occupations[p]
-                           << ", potential: " << all_potentials[p];
-            if (print_positions)
-            {
-                amrex::Print()
-                    << ", Position: (" << all_pos_x[p] << ", " << all_pos_y[p];
+            if(all_rel_diff[p] > THRESHOLD_REL_DIFF_TO_PRINT) {
+                amrex::Print() << std::left
+                               << "ID: "            << std::setw(6) << all_particle_ids[p]
+                               << ", charge/(e): "  << std::setw(6) << all_charge_units[p]
+                               << ", occupation: "  << std::setprecision(8) << std::setw(12) << all_occupations[p]
+                               << ", phi/(V): "     << std::setprecision(8) << std::setw(12) << all_potentials[p]
+                               << ", phi_rel_diff: "<< std::setw(15) << std::scientific << all_rel_diff[p];
+
+                if (print_positions)
+                {
+                    amrex::Print() << ", Position: (" 
+                                   << std::setw(10) << all_pos_x[p] 
+                                   << ", " << std::setw(10) << all_pos_y[p];
 #if AMREX_SPACEDIM == 3
-                amrex::Print() << ", " << all_pos_z[p];
+                    amrex::Print() << ", " << std::setw(10) << all_pos_z[p];
 #endif
-                amrex::Print() << ")";
-            }
-            amrex::Print() << "\n";
+                    amrex::Print() << ")";
+                }
+                amrex::Print() << "\n";
+            }            
             total_charge += all_charge_units[p] * all_occupations[p];
             total_charge_units += all_charge_units[p];
         }
         amrex::Print() << "total charge: " << total_charge << "\n";
+        Write_OutputFile();
     }
-    Write_OutputFile();
 }
 
 void c_PointChargeContainer::Compute_Occupation()
@@ -451,19 +483,21 @@ void c_PointChargeContainer::Compute_Occupation()
         auto &par_charge_unit = pti.get_charge_unit();
         auto *p_charge_unit = par_charge_unit.data();
 
+        auto &par_rel_diff = pti.get_relative_difference();
+        auto *p_par_rel_diff = par_rel_diff.data();
+        
         amrex::Real V0 = Get_V0();
         amrex::Real Et = Get_Et();
-        amrex::Real MF = Get_mixing_factor();
-
+        //amrex::Real MF = 0.5;
+        //int THRESHOLD_REL_DIFF_OCCUPATION_COMPUT = 1.e-2;
         amrex::ParallelFor(np,
                            [=] AMREX_GPU_DEVICE(int p)
                            {
-                               amrex::Real argument =
-                                   -(p_potential[p] - V0) / Et;
-                               amrex::Real new_occupation =
-                                   MathFunctions::Sigmoid(argument);
-                               p_occupation[p] = p_occupation[p] * MF +
-                                                 (1. - MF) * new_occupation;
+                               //if(p_par_rel_diff[p] > THRESHOLD_REL_DIFF_OCCUPATION_COMPUT) {
+                                   amrex::Real argument =
+                                       -(p_potential[p] - V0) / Et;
+                                   p_occupation[p] = MathFunctions::Sigmoid(argument);
+                               //}
                            });
     }
 }

--- a/Source/Input/MacroscopicProperties/PointChargeContainer.cpp
+++ b/Source/Input/MacroscopicProperties/PointChargeContainer.cpp
@@ -1,11 +1,11 @@
-#include <limits>
-#include <iomanip>
-#include <filesystem>
-
 #include "PointChargeContainer.H"
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_Parser.H>
+
+#include <filesystem>
+#include <iomanip>
+#include <limits>
 
 #include "../../Output/Output.H"
 #include "../../Solver/Transport/Transport.H"
@@ -42,18 +42,19 @@ void c_PointChargeContainer::Define_OutputFile()
         std::string main_output_foldername = rOutput.get_folder_name();
         std::string pc_foldername = main_output_foldername + "/point_charge";
 
-        //if (std::filesystem::exists(pc_foldername)) {
-        //    std::cout << "Directory exists: " << pc_foldername << "\n";
-        //} else {
-        //    try {
-        //        if (CreateDirectory(pc_foldername)) {
-        //        } else {
-        //            std::cout << "Failed to create directory, unknown reason.\n";
-        //        }
-        //    } catch (const std::filesystem::filesystem_error& e) {
-        //        std::cerr << "Filesystem error: " << e.what() << "\n";
-        //    }
-        //}a
+        // if (std::filesystem::exists(pc_foldername)) {
+        //     std::cout << "Directory exists: " << pc_foldername << "\n";
+        // } else {
+        //     try {
+        //         if (CreateDirectory(pc_foldername)) {
+        //         } else {
+        //             std::cout << "Failed to create directory, unknown
+        //             reason.\n";
+        //         }
+        //     } catch (const std::filesystem::filesystem_error& e) {
+        //         std::cerr << "Filesystem error: " << e.what() << "\n";
+        //     }
+        // }a
         UtilCreateCleanDirectory(pc_foldername, false);
         pc_stepwise_filename = pc_foldername + "/total_charge_vs_step.dat";
         outfile_pc_step.open(pc_stepwise_filename.c_str());
@@ -126,11 +127,9 @@ void c_PointChargeContainer::Check_PositionBounds(
         }
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             GeomUtils::Is_ID_Within_Bounds(ID, minID, maxID) == true,
-            "Point charge " + std::to_string(s) + " is out of bounds. ID: [" 
-            + std::to_string(ID[0]) + ", "
-            + std::to_string(ID[1]) + ", "
-            + std::to_string(ID[2]) + "] "
-            );
+            "Point charge " + std::to_string(s) + " is out of bounds. ID: [" +
+                std::to_string(ID[0]) + ", " + std::to_string(ID[1]) + ", " +
+                std::to_string(ID[2]) + "] ");
     }
 }
 
@@ -142,14 +141,14 @@ void c_PointChargeContainer::Read_PointCharges()
     queryArrWithParser(pp_main, "offset", vec_offset, 0, AMREX_SPACEDIM);
 
     amrex::Print() << "pc.offset / (nm): ";
-    for (const auto &v : vec_offset) amrex::Print() << v*1e9 << " ";
+    for (const auto &v : vec_offset) amrex::Print() << v * 1e9 << " ";
     amrex::Print() << "\n";
 
     amrex::Vector<amrex::Real> vec_scaling(AMREX_SPACEDIM, 1.0);
     queryArrWithParser(pp_main, "scaling", vec_scaling, 0, AMREX_SPACEDIM);
 
     amrex::Print() << "pc.scaling / (nm): ";
-    for (const auto &v : vec_scaling) amrex::Print() << v*1e9 << " ";
+    for (const auto &v : vec_scaling) amrex::Print() << v * 1e9 << " ";
     amrex::Print() << "\n";
 
     amrex::Vector<amrex::Real> vec_max_bound(AMREX_SPACEDIM, 1.0);
@@ -157,7 +156,7 @@ void c_PointChargeContainer::Read_PointCharges()
     for (int d = 0; d < AMREX_SPACEDIM; ++d)
     {
         vec_max_bound[d] = vec_offset[d] + vec_scaling[d];
-        amrex::Print() << vec_max_bound[d]*1e9 << " ";
+        amrex::Print() << vec_max_bound[d] * 1e9 << " ";
     }
     amrex::Print() << "\n";
 
@@ -274,7 +273,8 @@ void c_PointChargeContainer::Define(
             real_attribs[PCA::realPA::charge_unit] = charge_units[p];
             real_attribs[PCA::realPA::occupation] = occupations[p];
             real_attribs[PCA::realPA::potential] = 0.0;
-            real_attribs[PCA::realPA::rel_diff] = std::numeric_limits<double>::max(); 
+            real_attribs[PCA::realPA::rel_diff] =
+                std::numeric_limits<double>::max();
 
             std::pair<int, int> key{0, 0};  // {grid_index, tile_index}
             int lev = 0;
@@ -285,11 +285,12 @@ void c_PointChargeContainer::Define(
             particle_tile.push_back_real(real_attribs);
 
             // Print the details of the newly added particle
-            amrex::Print() << std::left << "ID: " << std::setw(8) << new_particle.id()
-                           << ", Pos/(nm): (";
+            amrex::Print() << std::left << "ID: " << std::setw(8)
+                           << new_particle.id() << ", Pos/(nm): (";
             for (int j = 0; j < AMREX_SPACEDIM; ++j)
             {
-                amrex::Print() << std::setw(12) << std::setprecision(8) << new_particle.pos(j) * 1e9;
+                amrex::Print() << std::setw(12) << std::setprecision(8)
+                               << new_particle.pos(j) * 1e9;
                 if (j < AMREX_SPACEDIM - 1)
                 {
                     amrex::Print() << ", ";
@@ -312,8 +313,8 @@ void c_PointChargeContainer::Print_Container(bool print_positions)
 {
     int lev = 0;
     Vector<int> particle_ids;
-    Vector<amrex::Real> charge_units, occupations, potentials, rel_diff,
-        pos_x, pos_y, pos_z;
+    Vector<amrex::Real> charge_units, occupations, potentials, rel_diff, pos_x,
+        pos_y, pos_z;
 
     for (c_PointChargeContainer::ParIter pti(*this, lev); pti.isValid(); ++pti)
     {
@@ -361,7 +362,7 @@ void c_PointChargeContainer::Print_Container(bool print_positions)
 
     // allocate global vectors
     Vector<int> all_particle_ids;
-    Vector<amrex::Real> all_charge_units, all_occupations, all_potentials, 
+    Vector<amrex::Real> all_charge_units, all_occupations, all_potentials,
         all_rel_diff, all_pos_x, all_pos_y, all_pos_z;
 
     if (ParallelDescriptor::IOProcessor())
@@ -426,26 +427,30 @@ void c_PointChargeContainer::Print_Container(bool print_positions)
         amrex::Print() << "number of charges: " << np << "\n";
         for (int p = 0; p < np; ++p)
         {
-            if(all_rel_diff[p] > THRESHOLD_REL_DIFF_TO_PRINT) {
-                amrex::Print() << std::left
-                               << "ID: "            << std::setw(6) << all_particle_ids[p]
-                               << ", charge/(e): "  << std::setw(6) << all_charge_units[p]
-                               << ", occupation: "  << std::setprecision(8) << std::setw(12) << all_occupations[p]
-                               << ", phi/(V): "     << std::setprecision(8) << std::setw(12) << all_potentials[p]
-                               << ", phi_rel_diff: "<< std::setw(15) << std::scientific << all_rel_diff[p];
+            if (all_rel_diff[p] > THRESHOLD_REL_DIFF_TO_PRINT)
+            {
+                amrex::Print()
+                    << std::left << "ID: " << std::setw(6)
+                    << all_particle_ids[p] << ", charge/(e): " << std::setw(6)
+                    << all_charge_units[p]
+                    << ", occupation: " << std::setprecision(8) << std::setw(12)
+                    << all_occupations[p]
+                    << ", phi/(V): " << std::setprecision(8) << std::setw(12)
+                    << all_potentials[p] << ", phi_rel_diff: " << std::setw(15)
+                    << std::scientific << all_rel_diff[p];
 
                 if (print_positions)
                 {
-                    amrex::Print() << ", Position: (" 
-                                   << std::setw(10) << all_pos_x[p] 
-                                   << ", " << std::setw(10) << all_pos_y[p];
+                    amrex::Print()
+                        << ", Position: (" << std::setw(10) << all_pos_x[p]
+                        << ", " << std::setw(10) << all_pos_y[p];
 #if AMREX_SPACEDIM == 3
                     amrex::Print() << ", " << std::setw(10) << all_pos_z[p];
 #endif
                     amrex::Print() << ")";
                 }
                 amrex::Print() << "\n";
-            }            
+            }
             total_charge += all_charge_units[p] * all_occupations[p];
             total_charge_units += all_charge_units[p];
         }
@@ -485,18 +490,20 @@ void c_PointChargeContainer::Compute_Occupation()
 
         auto &par_rel_diff = pti.get_relative_difference();
         auto *p_par_rel_diff = par_rel_diff.data();
-        
+
         amrex::Real V0 = Get_V0();
         amrex::Real Et = Get_Et();
-        //amrex::Real MF = 0.5;
-        //int THRESHOLD_REL_DIFF_OCCUPATION_COMPUT = 1.e-2;
+        // amrex::Real MF = 0.5;
+        // int THRESHOLD_REL_DIFF_OCCUPATION_COMPUT = 1.e-2;
         amrex::ParallelFor(np,
                            [=] AMREX_GPU_DEVICE(int p)
                            {
-                               //if(p_par_rel_diff[p] > THRESHOLD_REL_DIFF_OCCUPATION_COMPUT) {
-                                   amrex::Real argument =
-                                       -(p_potential[p] - V0) / Et;
-                                   p_occupation[p] = MathFunctions::Sigmoid(argument);
+                               // if(p_par_rel_diff[p] >
+                               // THRESHOLD_REL_DIFF_OCCUPATION_COMPUT) {
+                               amrex::Real argument =
+                                   -(p_potential[p] - V0) / Et;
+                               p_occupation[p] =
+                                   MathFunctions::Sigmoid(argument);
                                //}
                            });
     }

--- a/Source/Solver/Transport/NEGF/CNT.H
+++ b/Source/Solver/Transport/NEGF/CNT.H
@@ -78,23 +78,17 @@ class c_CNT : public c_NEGF_Common<ComplexType[NUM_MODES]>
         MatrixBlock<BlkType> &gr, const ComplexType EmU) final;
 
    public:
-    struct Get1DSiteID
-    {
-        AMREX_GPU_HOST_DEVICE int operator()(int global_par_id) const
-        {
-            return static_cast<int>(
-                amrex::Math::floor((global_par_id - 1) / type_id[0]));
-        }
-        amrex::Array<int, 2> type_id;
-    };
 
-    static Get1DSiteID get_1D_site_id() { return Get1DSiteID{type_id}; }
+    static int get_1D_site_id(int par_id_local_to_NS) {
+        return static_cast<int>(
+            amrex::Math::floor((par_id_local_to_NS - 1) / type_id[0]));
+    }
 
     struct GetAtomIDAtSite
     {
-        AMREX_GPU_HOST_DEVICE int operator()(int global_par_id) const
+        AMREX_GPU_HOST_DEVICE int operator()(int par_id_local_to_NS) const
         {
-            return static_cast<int>((global_par_id - 1) % type_id[0]);
+            return static_cast<int>((par_id_local_to_NS - 1) % type_id[0]);
         }
         amrex::Array<int, 2> type_id;
     };

--- a/Source/Solver/Transport/NEGF/CNT.H
+++ b/Source/Solver/Transport/NEGF/CNT.H
@@ -78,8 +78,8 @@ class c_CNT : public c_NEGF_Common<ComplexType[NUM_MODES]>
         MatrixBlock<BlkType> &gr, const ComplexType EmU) final;
 
    public:
-
-    static int get_1D_site_id(int par_id_local_to_NS) {
+    static int get_1D_site_id(int par_id_local_to_NS)
+    {
         return static_cast<int>(
             amrex::Math::floor((par_id_local_to_NS - 1) / type_id[0]));
     }

--- a/Source/Solver/Transport/NEGF/Graphene.H
+++ b/Source/Solver/Transport/NEGF/Graphene.H
@@ -42,8 +42,8 @@ class c_Graphene : public c_NEGF_Common<ComplexType[NUM_MODES][NUM_MODES]>
     }
 
    public:
-
-    static int get_1D_site_id(int par_id_local_to_NS) {
+    static int get_1D_site_id(int par_id_local_to_NS)
+    {
         return static_cast<int>(
             amrex::Math::floor((par_id_local_to_NS - 1) / type_id[0]));
     }

--- a/Source/Solver/Transport/NEGF/Graphene.H
+++ b/Source/Solver/Transport/NEGF/Graphene.H
@@ -42,17 +42,11 @@ class c_Graphene : public c_NEGF_Common<ComplexType[NUM_MODES][NUM_MODES]>
     }
 
    public:
-    struct Get1DSiteID
-    {
-        AMREX_GPU_HOST_DEVICE int operator()(int global_par_id) const
-        {
-            return static_cast<int>(
-                amrex::Math::floor((global_par_id - 1) / type_id[0]));
-        }
-        amrex::Array<int, 2> type_id;
-    };
 
-    static Get1DSiteID get_1D_site_id() { return Get1DSiteID{type_id}; }
+    static int get_1D_site_id(int par_id_local_to_NS) {
+        return static_cast<int>(
+            amrex::Math::floor((par_id_local_to_NS - 1) / type_id[0]));
+    }
 
     struct GetAtomIDAtSite
     {

--- a/Source/Solver/Transport/NEGF/NEGF_Common.H
+++ b/Source/Solver/Transport/NEGF/NEGF_Common.H
@@ -159,7 +159,6 @@ class c_NEGF_Common : protected MatrixBlock<T>, private c_IntegrationPath
 #endif
 
     void Set_KeyParams(const std::string &NS_name_str, const int &NS_id_counter,
-                       const int &NS_field_sites_offset,
                        const amrex::Real &NS_initial_deposit_value);
     void Define_FoldersAndFiles(const std::string &negf_foldername_str);
     void Read_NanostructureProperties();
@@ -326,8 +325,7 @@ class c_NEGF_Common : protected MatrixBlock<T>, private c_IntegrationPath
     int num_proc = 1;
     int NS_Id = 0;
     int site_size_loc_offset = 0;
-    int site_id_offset = 0;
-    int NS_field_sites_offset = 0;
+    int min_local_site_id = 0;
     MPI_Datatype MPI_BlkType;
 
     /*Nanostructure params*/
@@ -460,7 +458,6 @@ class c_NEGF_Common : protected MatrixBlock<T>, private c_IntegrationPath
 
     void Initialize_NEGF_Params(const std::string &NS_name_str,
                                 const int &NS_id_counter,
-                                const int &NS_field_sites_offset,
                                 const amrex::Real &NS_initial_deposit_value,
                                 const std::string &negf_foldername_str);
     void Define_MPISendCountAndDisp();

--- a/Source/Solver/Transport/NEGF/NEGF_Common.cpp
+++ b/Source/Solver/Transport/NEGF/NEGF_Common.cpp
@@ -24,12 +24,10 @@ const std::map<std::string, AxisType> map_strToAxisType = {
 template <typename T>
 void c_NEGF_Common<T>::Set_KeyParams(const std::string &name_str,
                                      const int &id_counter,
-                                     const int &field_sites_offset,
                                      const amrex::Real &initial_deposit_value)
 {
     name = name_str;
     NS_Id = id_counter;
-    NS_field_sites_offset = field_sites_offset;
     initial_charge = initial_deposit_value;
 
     num_proc = amrex::ParallelDescriptor::NProcs();
@@ -141,7 +139,7 @@ void c_NEGF_Common<T>::Define_MPISendCountAndDisp()
         std::fill(MPI_send_count.begin(), MPI_send_count.end(), 0);
         std::fill(MPI_send_disp.begin(), MPI_send_disp.end(), 0);
     }
-    MPI_Gather(&(site_id_offset), 1, MPI_INT, MPI_send_disp.data(), 1, MPI_INT,
+    MPI_Gather(&(min_local_site_id), 1, MPI_INT, MPI_send_disp.data(), 1, MPI_INT,
                ParallelDescriptor::IOProcessorNumber(),
                ParallelDescriptor::Communicator());
 
@@ -199,7 +197,7 @@ void c_NEGF_Common<T>::Initialize_ChargeAtFieldSites()
         //    // bool full_match = true;
         //    // for(int i=0; i < num_local_field_sites; ++i)
         //    // {
-        //    //     if(h_n_curr_in_loc(i) != h_n_curr_in_glo(i+site_id_offset)
+        //    //     if(h_n_curr_in_loc(i) != h_n_curr_in_glo(i+min_local_site_id)
         //    )
 
         //   //         full_match = false;
@@ -207,7 +205,7 @@ void c_NEGF_Common<T>::Initialize_ChargeAtFieldSites()
         //   //                 + std::to_string(i) + " " +
         //   std::to_string(h_n_curr_in_loc(i)) + " "
         //   //                 +
-        //   std::to_string(h_n_curr_in_glo(i+site_id_offset)));
+        //   std::to_string(h_n_curr_in_glo(i+min_local_site_id)));
         //   //     }
         //   // }
         //   // std::cout << "process: " << my_rank << " full_match: " <<
@@ -745,8 +743,6 @@ void c_NEGF_Common<T>::Print_KeyParams()
 {
     amrex::Print() << "##### name: " << name << "\n";
     amrex::Print() << "##### NS_Id: " << NS_Id << "\n";
-    amrex::Print() << "##### NS_field_sites_offset: " << NS_field_sites_offset
-                   << "\n";
     amrex::Print() << "##### initial_charge: " << initial_charge << "\n";
     amrex::Print() << "##### num_proc: " << num_proc << "\n";
     amrex::Print() << "##### my_rank: " << my_rank << "\n";
@@ -1190,10 +1186,10 @@ void c_NEGF_Common<T>::Define_MatrixPartition()
 template <typename T>
 void c_NEGF_Common<T>::Initialize_NEGF_Params(
     const std::string &name_str, const int &id_counter,
-    const int &field_sites_offset, const amrex::Real &initial_deposit_value,
+    const amrex::Real &initial_deposit_value,
     const std::string &negf_foldername_str)
 {
-    Set_KeyParams(name_str, id_counter, field_sites_offset,
+    Set_KeyParams(name_str, id_counter, 
                   initial_deposit_value);
 
     Define_FoldersAndFiles(negf_foldername_str);

--- a/Source/Solver/Transport/NEGF/NEGF_Common.cpp
+++ b/Source/Solver/Transport/NEGF/NEGF_Common.cpp
@@ -139,8 +139,8 @@ void c_NEGF_Common<T>::Define_MPISendCountAndDisp()
         std::fill(MPI_send_count.begin(), MPI_send_count.end(), 0);
         std::fill(MPI_send_disp.begin(), MPI_send_disp.end(), 0);
     }
-    MPI_Gather(&(min_local_site_id), 1, MPI_INT, MPI_send_disp.data(), 1, MPI_INT,
-               ParallelDescriptor::IOProcessorNumber(),
+    MPI_Gather(&(min_local_site_id), 1, MPI_INT, MPI_send_disp.data(), 1,
+               MPI_INT, ParallelDescriptor::IOProcessorNumber(),
                ParallelDescriptor::Communicator());
 
     MPI_Gather(&(num_local_field_sites), 1, MPI_INT, MPI_send_count.data(), 1,
@@ -197,7 +197,8 @@ void c_NEGF_Common<T>::Initialize_ChargeAtFieldSites()
         //    // bool full_match = true;
         //    // for(int i=0; i < num_local_field_sites; ++i)
         //    // {
-        //    //     if(h_n_curr_in_loc(i) != h_n_curr_in_glo(i+min_local_site_id)
+        //    //     if(h_n_curr_in_loc(i) !=
+        //    h_n_curr_in_glo(i+min_local_site_id)
         //    )
 
         //   //         full_match = false;
@@ -1189,8 +1190,7 @@ void c_NEGF_Common<T>::Initialize_NEGF_Params(
     const amrex::Real &initial_deposit_value,
     const std::string &negf_foldername_str)
 {
-    Set_KeyParams(name_str, id_counter, 
-                  initial_deposit_value);
+    Set_KeyParams(name_str, id_counter, initial_deposit_value);
 
     Define_FoldersAndFiles(negf_foldername_str);
 

--- a/Source/Solver/Transport/Nanostructure.H
+++ b/Source/Solver/Transport/Nanostructure.H
@@ -27,7 +27,7 @@ class c_Nanostructure
     amrex::MultiFab *p_mf_deposit = nullptr;
     const amrex::GpuArray<int, AMREX_SPACEDIM> *_n_cell;
     amrex::Vector<s_Position3D> pos_vec;
-    int particle_id_offset=0;
+    int particle_id_offset = 0;
 
     void Fill_AtomLocations();
     void Read_AtomLocations();

--- a/Source/Solver/Transport/Nanostructure.H
+++ b/Source/Solver/Transport/Nanostructure.H
@@ -27,6 +27,7 @@ class c_Nanostructure
     amrex::MultiFab *p_mf_deposit = nullptr;
     const amrex::GpuArray<int, AMREX_SPACEDIM> *_n_cell;
     amrex::Vector<s_Position3D> pos_vec;
+    int particle_id_offset=0;
 
     void Fill_AtomLocations();
     void Read_AtomLocations();
@@ -41,8 +42,7 @@ class c_Nanostructure
                     const int NS_id, const std::string NS_gather_str,
                     const std::string NS_deposit_str,
                     const amrex::Real NS_initial_deposit_value,
-                    const int use_negf, const std::string negf_foldername_str,
-                    const int NS_field_sites_offset);
+                    const int use_negf, const std::string negf_foldername_str);
 
     void Evaluate_LocalFieldSites();
     void Gather_MeshAttributeAtAtoms();

--- a/Source/Solver/Transport/Nanostructure.cpp
+++ b/Source/Solver/Transport/Nanostructure.cpp
@@ -97,7 +97,7 @@ void c_Nanostructure<NSType>::Fill_AtomLocations()
             ParticleType p;
             p.id() = ParticleType::NextID();
 
-            if(i==0) particle_id_offset = p.id()-1;
+            if (i == 0) particle_id_offset = p.id() - 1;
 
             p.cpu() = ParallelDescriptor::MyProc();
 
@@ -128,7 +128,7 @@ void c_Nanostructure<NSType>::Fill_AtomLocations()
     ParallelDescriptor::Bcast(&particle_id_offset, 1,
                               ParallelDescriptor::IOProcessorNumber());
 
-    Redistribute();  
+    Redistribute();
 }
 
 template <typename NSType>
@@ -378,8 +378,7 @@ void c_Nanostructure<NSType>::Deposit_AtomAttributeToMesh()
         int atoms_per_field_site = NSType::num_atoms_per_field_site;
         int SIO = NSType::min_local_site_id;
 
-        amrex::Real vol =
-            AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
+        amrex::Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
 
         auto const &h_n_curr_in_loc = NSType::h_n_curr_in_loc_data.table();
 
@@ -460,7 +459,8 @@ void c_Nanostructure<NSType>::Obtain_PotentialAtSites()
 
                         int site_id = p_site_id[p];
 
-                        int atom_id_at_site = get_atom_id_at_site(par_id_local_to_NS);
+                        int atom_id_at_site =
+                            get_atom_id_at_site(par_id_local_to_NS);
 
                         int remainder =
                             atom_id_at_site % num_atoms_per_field_site;

--- a/Source/Solver/Transport/Transport.cpp
+++ b/Source/Solver/Transport/Transport.cpp
@@ -372,7 +372,6 @@ int c_TransportSolver::Instantiate_Materials()
         amrex::Print() << "##### Instantiating material: " << name << "\n";
 
         int field_sites = 0;
-        int NS_field_sites_offset = NS_field_sites_cumulative.back();
         switch (c_TransportSolver::map_NSType_enum.at(Get_NS_type_str(name)))
         {
             case s_NS_Type::CNT:
@@ -381,8 +380,7 @@ int c_TransportSolver::Instantiate_Materials()
                 vp_CNT.push_back(std::make_unique<c_Nanostructure<T>>(
                     *_geom, *_dm, *_ba, name, NS_id_counter,
                     NS_gather_field_str, NS_deposit_field_str,
-                    NS_initial_deposit_value, use_negf, negf_foldername_str,
-                    NS_field_sites_offset));
+                    NS_initial_deposit_value, use_negf, negf_foldername_str));
                 field_sites = vp_CNT.back()->get_num_field_sites();
                 break;
             }
@@ -393,8 +391,7 @@ int c_TransportSolver::Instantiate_Materials()
                 vp_Graphene.push_back(std::make_unique<c_Nanostructure<T>>(
                     *_geom, *_dm, *_ba, name, NS_id_counter,
                     NS_gather_field_str, NS_deposit_field_str,
-                    NS_initial_deposit_value, use_negf, negf_foldername_str,
-                    NS_field_sites_offset));
+                    NS_initial_deposit_value, use_negf, negf_foldername_str));
                 field_sites = vp_Graphene.back()->get_num_field_sites();
                 amrex::Abort("NS_type graphene is not yet defined.");
                 break;

--- a/Source/Utils/CodeUtils/CodeUtil.cpp
+++ b/Source/Utils/CodeUtils/CodeUtil.cpp
@@ -710,7 +710,7 @@ bool GeomUtils::Is_ID_Within_Bounds(const amrex::Vector<int> &ID,
     bool is_inside = true;
     for (int d = 0; d < AMREX_SPACEDIM; ++d)
     {
-        is_inside *= (ID[d] >= minID[d] && ID[d] < maxID[d]);
+        is_inside *= (ID[d] >= minID[d] && ID[d] <= maxID[d]);
     }
     return is_inside;
 }

--- a/Source/Utils/CodeUtils/ParticleStructure.H
+++ b/Source/Utils/CodeUtils/ParticleStructure.H
@@ -12,7 +12,7 @@
 
 // Extra Particle attributes in Struct-of-Arrays form
 // real: phi, charge
-// int: site_id 
+// int: site_id
 
 struct realPA  // real Particle Attribute
 {
@@ -28,7 +28,7 @@ struct intPA  // integer Particle Attribute
 {
     enum
     {
-        site_id,  //field_site_id local to nanostructure
+        site_id,  // field_site_id local to nanostructure
         NUM
     };
 };
@@ -104,9 +104,7 @@ class MyParIter
 
     const IntVector &get_site_id() const
     {
-        return this->GetStructOfArrays().GetIntData(
-            intPA::site_id);
+        return this->GetStructOfArrays().GetIntData(intPA::site_id);
     }
-
 };
 #endif

--- a/Source/Utils/CodeUtils/ParticleStructure.H
+++ b/Source/Utils/CodeUtils/ParticleStructure.H
@@ -12,8 +12,7 @@
 
 // Extra Particle attributes in Struct-of-Arrays form
 // real: phi, charge
-// int: 2 //cell_id, atom_id (from atom_id we can obtain (ring_number,
-// azimuthal_number)
+// int: site_id 
 
 struct realPA  // real Particle Attribute
 {
@@ -29,7 +28,7 @@ struct intPA  // integer Particle Attribute
 {
     enum
     {
-        cid,  // cell id
+        site_id,  //field_site_id local to nanostructure
         NUM
     };
 };
@@ -103,9 +102,11 @@ class MyParIter
         return GetStructOfArrays().GetIntData(comp);
     }
 
-    // get realPA
-    // std::array<> (int comp) {
-    //     return GetArrayOfStructs();
-    // }
+    const IntVector &get_site_id() const
+    {
+        return this->GetStructOfArrays().GetIntData(
+            intPA::site_id);
+    }
+
 };
 #endif

--- a/input/negf/point_charges/topgate_CNTFET
+++ b/input/negf/point_charges/topgate_CNTFET
@@ -12,7 +12,7 @@ amrex.the_arena_is_managed=1
 ################################
 ##### Some Important Params ####
 ################################
-my_constants.gx = 1
+my_constants.gx = 2
 my_constants.gy = 16
 my_constants.gz = 2
 
@@ -23,9 +23,9 @@ my_constants.periodicity_length = periodicity_factor * unitcells_per_D_CN * L_un
 
 
 my_constants.Vds = 0.   #Drain-Source voltage [V]
-my_constants.Vgs_min = -0.8
+my_constants.Vgs_min = -2
 my_constants.Vgs_max = 1
-my_constants.Nsteps = 2
+my_constants.Nsteps = 16
 my_constants.dt = 1./(Nsteps-1)
 
 
@@ -345,7 +345,7 @@ NS_default.num_recursive_parts = 2
 #NS_default.read_negf_foldername =
 NS_default.E_valence_min = -10
 NS_default.E_pole_max    = 3
-NS_default.E_zPlus_imag  = 1.e-7
+NS_default.E_zPlus_imag  = 1.e-6
 
 CNT_default.type_id = m_index n_index    
 CNT_default.acc = bond_length

--- a/input/negf/point_charges/topgate_CNTFET
+++ b/input/negf/point_charges/topgate_CNTFET
@@ -24,14 +24,14 @@ my_constants.periodicity_length = periodicity_factor * unitcells_per_D_CN * L_un
 
 my_constants.Vds = 0.   #Drain-Source voltage [V]
 my_constants.Vgs_min = -2
-my_constants.Vgs_max = 1
-my_constants.Nsteps = 16
+my_constants.Vgs_max = 0.4
+my_constants.Nsteps = 13
 my_constants.dt = 1./(Nsteps-1)
 
 
 plot.folder_name = /global/cfs/projectdirs/m4540/eXstatic/point_charge/topgate_CNTFET/dummy
-plot.write_after_init = 1
-plot.write_interval = 1
+plot.write_after_init = 0
+plot.write_interval = 10000
 
 transport.flag_compute_DOS = 1 #DOS, Transmission, Conductance
 transport.flag_write_LDOS = 0
@@ -57,7 +57,7 @@ my_constants.epsilon_GO     = 25*epsilon_0 #HfO2
 my_constants.epsilon_S      = 3.9*epsilon_0 #SiO2
 
 my_constants.SV = 0.      #source voltage [V]
-my_constants.Ef = -0.28    #Palladium Contact Fermi level [eV] 
+my_constants.Ef = -0.2    #Palladium Contact Fermi level [eV] 
 
 my_constants.MGO_gap = 5*dx + dx/5. #gap between metal and gate oxide
 my_constants.MB_gap  = dx #2*dx/5.
@@ -162,9 +162,9 @@ my_constants.FET_width   = CM_width
 
 charge_density_source.type = point_charge
 pc.flag_vary_occupation = 1
-pc.mixing_factor = 0
-pc.scaling = (GO_width - 8*dx) (Channel_length - 8*dy) (GO_thickness - 8*dz)
-pc.offset =  (-GO_width/2. + 4*dx) (-Channel_length/2. + 4*dy) (GO_bottom + 4*dz)
+pc.mixing_factor = 0.1
+pc.offset =  (-GO_width/2. + 10*dx) (-G_length/2.) (GO_bottom + 4*dz)
+pc.scaling = (GO_width - 20*dx) (G_length) (GO_thickness - 8*dz)
 pc.Et = 2
 pc.V0 = 0.5
 pc.default_charge_unit = 1
@@ -319,7 +319,7 @@ transport.selfconsistency_algorithm = broyden_second
 transport.reset_with_previous_charge_distribution = 1
 transport.initialize_inverse_jacobian = 0
 transport.gate_terminal_type = Boundary
-transport.Broyden_threshold_maxstep = 200
+transport.Broyden_threshold_maxstep = 400
 transport.gate_terminal_type = EB
 
 NS_default.num_unitcells = N_unitcells


### PR DESCRIPTION

-Point charge implementation was corrected.
Specifically the way we keep track of atom IDs was modified in CNTs.
This was required because when point charges were added as a separate 
particle data structure, it was messing up with IDs of material atom IDs.
-Modified top gate configuration to simulate point charges.