### PR TITLE
removing gpu binding in perlmutter scripts

### DIFF
--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rho1 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rho1 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot2/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot2/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.2e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rho1Dot2 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.2e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rho1Dot2 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot4/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot4/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.4e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rho1Dot4 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.4e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rho1Dot4 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_qFixed
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_qFixed
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.flag_vary_occupation=0 pc.charge_density=0.7e18 my_constants.Vgs_max=0.6 my_constants.Vgs_min=-1 my_constants.Nsteps=9 plot.folder_name = /global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_2D/qFixed_ZcenterGO use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.flag_vary_occupation=0 pc.charge_density=0.7e18 my_constants.Vgs_max=0.6 my_constants.Vgs_min=-1 my_constants.Nsteps=9 plot.folder_name = /global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_2D/qFixed_ZcenterGO use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed0 use_diagnostics=1 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed0 use_diagnostics=1 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed1
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed1
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed1_4dz use_diagnostics=0 pc.random_seed=1 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed1_4dz use_diagnostics=0 pc.random_seed=1 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed10
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed10
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed10 use_diagnostics=1 pc.random_seed=10 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed10 use_diagnostics=1 pc.random_seed=10 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed11
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed11
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed11 use_diagnostics=1 pc.random_seed=11 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed11 use_diagnostics=1 pc.random_seed=11 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed12
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed12
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed12 use_diagnostics=1 pc.random_seed=12 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed12 use_diagnostics=1 pc.random_seed=12 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed13
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed13
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed13 use_diagnostics=1 pc.random_seed=13 ##restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed13 use_diagnostics=1 pc.random_seed=13 ##restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed14
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed14
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed14 use_diagnostics=1 pc.random_seed=14 ##restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed14 use_diagnostics=1 pc.random_seed=14 ##restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed15
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed15
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed15 use_diagnostics=1 pc.random_seed=15 ##restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed15 use_diagnostics=1 pc.random_seed=15 ##restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed16
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed16
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed16 use_diagnostics=1 pc.random_seed=16 ##restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed16 use_diagnostics=1 pc.random_seed=16 ##restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed2
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed2
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed2 use_diagnostics=0 pc.random_seed=2 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed2 use_diagnostics=0 pc.random_seed=2 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed3
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed3
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed3 use_diagnostics=0 pc.random_seed=3 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed3 use_diagnostics=0 pc.random_seed=3 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed4
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed4
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed4 use_diagnostics=1 pc.random_seed=4 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed4 use_diagnostics=1 pc.random_seed=4 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed5
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed5
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed5 use_diagnostics=1 pc.random_seed=5 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed5 use_diagnostics=1 pc.random_seed=5 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed6
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed6
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed6 use_diagnostics=1 pc.random_seed=6 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed6 use_diagnostics=1 pc.random_seed=6 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed7
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed7
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed7 use_diagnostics=1 pc.random_seed=7 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed7 use_diagnostics=1 pc.random_seed=7 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed8
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed8
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed8 use_diagnostics=1 pc.random_seed=8 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed8 use_diagnostics=1 pc.random_seed=8 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed9
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rho1Dot6/perl_rseed9
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed9 use_diagnostics=1 pc.random_seed=9 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2D pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed9 use_diagnostics=1 pc.random_seed=9 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rhoDot2/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rhoDot2/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=.2e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rhoDot2 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=.2e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rhoDot2 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rhoDot4/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rhoDot4/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=.4e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rhoDot4 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=.4e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rhoDot4 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rhoDot6/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rhoDot6/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rhoDot6 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rhoDot6 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rhoDot8/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_2D/rhoDot8/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=.8e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rhoDot8 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=.8e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_2D/rhoDot8 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot1/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot1/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.1e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot1 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.1e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot1 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot2/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot2/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.2e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot2 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.2e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot2 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot3/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot3/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.3e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot3 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.3e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot3 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot4/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot4/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.4e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot4 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.4e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot4 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot5/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot5/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.5e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot5 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.5e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot5 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot6/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/density_variation_3D/rhoDot6/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.6e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot6 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.6e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/density_variation_3D/rhoDot6 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_1nmSpacing/perl_num15
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_1nmSpacing/perl_num15
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=1e-9 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_1nmSpacing/ChargeNum15 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=1e-9 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_1nmSpacing/ChargeNum15 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_1nmSpacing/perl_num3
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_1nmSpacing/perl_num3
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2  my_constants.Xoffset=0 my_constants.Yoffset=1e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_1nmSpacing/ChargeNum3 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2  my_constants.Xoffset=0 my_constants.Yoffset=1e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_1nmSpacing/ChargeNum3 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_1nmSpacing/perl_num9
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_1nmSpacing/perl_num9
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=1e-9 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_1nmSpacing/ChargeNum9 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=1e-9 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_1nmSpacing/ChargeNum9 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot15nmSpacing/perl_num15
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot15nmSpacing/perl_num15
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=0.15e-9 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot15nmSpacing/ChargeNum15 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=0.15e-9 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot15nmSpacing/ChargeNum15 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot15nmSpacing/perl_num15_notPeriodic
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot15nmSpacing/perl_num15_notPeriodic
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster_notPeriodic my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=0.15e-9 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot15nmSpacing/ChargeNum15_notPeriodic use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster_notPeriodic my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=0.15e-9 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot15nmSpacing/ChargeNum15_notPeriodic use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot15nmSpacing/perl_num3
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot15nmSpacing/perl_num3
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2  my_constants.Xoffset=0 my_constants.Yoffset=0.15e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot15nmSpacing/ChargeNum3 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2  my_constants.Xoffset=0 my_constants.Yoffset=0.15e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot15nmSpacing/ChargeNum3 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot15nmSpacing/perl_num9
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot15nmSpacing/perl_num9
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2  my_constants.Xoffset=0 my_constants.Yoffset=0.15e-9 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot15nmSpacing/ChargeNum9 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2  my_constants.Xoffset=0 my_constants.Yoffset=0.15e-9 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot15nmSpacing/ChargeNum9 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot3nmSpacing/perl_num15
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot3nmSpacing/perl_num15
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=3e-10 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot3nmSpacing/ChargeNum15 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=3e-10 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot3nmSpacing/ChargeNum15 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot3nmSpacing/perl_num3
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot3nmSpacing/perl_num3
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2  my_constants.Xoffset=0 my_constants.Yoffset=3e-10 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot3nmSpacing/ChargeNum3 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2  my_constants.Xoffset=0 my_constants.Yoffset=3e-10 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot3nmSpacing/ChargeNum3 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot3nmSpacing/perl_num9
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot3nmSpacing/perl_num9
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=3e-10 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot3nmSpacing/ChargeNum9 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=3e-10 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot3nmSpacing/ChargeNum9 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot5Spacing/perl_num15
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot5Spacing/perl_num15
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=5e-10 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot5nmSpacing/ChargeNum15 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=5e-10 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot5nmSpacing/ChargeNum15 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot5Spacing/perl_num3
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot5Spacing/perl_num3
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2  my_constants.Xoffset=0 my_constants.Yoffset=5e-10 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot5nmSpacing/ChargeNum3 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2  my_constants.Xoffset=0 my_constants.Yoffset=5e-10 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot5nmSpacing/ChargeNum3 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot5Spacing/perl_num9
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/axialLine_dot5Spacing/perl_num9
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=5e-10 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot5nmSpacing/ChargeNum9 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0 my_constants.Yoffset=5e-10 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/axialCharge_dot5nmSpacing/ChargeNum9 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_1nmSpacing/perl_num3
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_1nmSpacing/perl_num3
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=1e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_1nmSpacing/ChargeNum3 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=1e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_1nmSpacing/ChargeNum3 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_1nmSpacing/perl_num5
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_1nmSpacing/perl_num5
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 128 -c 32 --cpu_bind=cores -G 128 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_singleCharge my_constants.Ef=-0.2 my_constants.Zoffset=0 my_constants.Xoffset=1e-9 pc.num=5 my_constants.periodicity_factor=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_1nmSpacing/ChargeNum5 use_diagnostics=1
+srun -n 128 -c 32 --cpu_bind=cores -G 128 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_singleCharge my_constants.Ef=-0.2 my_constants.Zoffset=0 my_constants.Xoffset=1e-9 pc.num=5 my_constants.periodicity_factor=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_1nmSpacing/ChargeNum5 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot15nmSpacing/perl_num15
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot15nmSpacing/perl_num15
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.15e-9 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot15nmSpacing/ChargeNum15 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.15e-9 pc.num=15 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot15nmSpacing/ChargeNum15 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot15nmSpacing/perl_num3
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot15nmSpacing/perl_num3
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.15e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot15nmSpacing/ChargeNum3 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.15e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot15nmSpacing/ChargeNum3 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot15nmSpacing/perl_num9
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot15nmSpacing/perl_num9
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.15e-9 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot15nmSpacing/ChargeNum9 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.15e-9 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot15nmSpacing/ChargeNum9 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot3nmSpacing/perl_num3
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot3nmSpacing/perl_num3
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.3e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot3nmSpacing/ChargeNum3 use_diagnostics=0
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.3e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot3nmSpacing/ChargeNum3 use_diagnostics=0

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot3nmSpacing/perl_num9
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot3nmSpacing/perl_num9
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.3e-9 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot3nmSpacing/ChargeNum9 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.3e-9 pc.num=9 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot3nmSpacing/ChargeNum9 use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot5nmSpacing/perl_num3
+++ b/perlmutter_scripts/pointCharge_topgate/line_traps/crossLine_dot5nmSpacing/perl_num3
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.5e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot5nmSpacing/ChargeNum3 use_diagnostics=0
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 my_constants.Xoffset=0.5e-9 pc.num=3 my_constants.Vgs_max=1.0 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/crossCharge_dot5nmSpacing/ChargeNum3 use_diagnostics=0

--- a/perlmutter_scripts/pointCharge_topgate/no_trap/Efm1/perl_noCharge
+++ b/perlmutter_scripts/pointCharge_topgate/no_trap/Efm1/perl_noCharge
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-1 pc.num=0 my_constants.Vgs_max=1.5 my_constants.Vgs_min=-2 my_constants.Nsteps=36 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/no_charge/Efm1 use_diagnostics=0
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-1 pc.num=0 my_constants.Vgs_max=1.5 my_constants.Vgs_min=-2 my_constants.Nsteps=36 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/no_charge/Efm1 use_diagnostics=0

--- a/perlmutter_scripts/pointCharge_topgate/no_trap/EfmDot2/perl_noCharge
+++ b/perlmutter_scripts/pointCharge_topgate/no_trap/EfmDot2/perl_noCharge
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 pc.num=0 my_constants.Vgs_max=1 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/no_charge/EfmDot2 use_diagnostics=0
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 pc.num=0 my_constants.Vgs_max=1 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/no_charge/EfmDot2 use_diagnostics=0

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_qFixed
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_qFixed
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.flag_vary_occupation=0 pc.charge_density=0.7e18 my_constants.Vgs_max=0.6 my_constants.Vgs_min=-1 my_constants.Nsteps=9 plot.folder_name = /global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_2D/qFixed_ZcenterGO use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.flag_vary_occupation=0 pc.charge_density=0.7e18 my_constants.Vgs_max=0.6 my_constants.Vgs_min=-1 my_constants.Nsteps=9 plot.folder_name = /global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_2D/qFixed_ZcenterGO use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed0 use_diagnostics=1 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed0 use_diagnostics=1 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed1
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed1
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed1_4dz use_diagnostics=0 pc.random_seed=1 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed1_4dz use_diagnostics=0 pc.random_seed=1 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed10
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed10
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed10 use_diagnostics=1 pc.random_seed=10 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed10 use_diagnostics=1 pc.random_seed=10 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed11
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed11
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed11 use_diagnostics=1 pc.random_seed=11 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed11 use_diagnostics=1 pc.random_seed=11 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed12
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed12
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed12 use_diagnostics=1 pc.random_seed=12 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed12 use_diagnostics=1 pc.random_seed=12 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed13
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed13
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed13 use_diagnostics=1 pc.random_seed=13 ##restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed13 use_diagnostics=1 pc.random_seed=13 ##restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed14
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed14
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed14 use_diagnostics=1 pc.random_seed=14 ##restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed14 use_diagnostics=1 pc.random_seed=14 ##restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed15
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed15
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed15 use_diagnostics=1 pc.random_seed=15 ##restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed15 use_diagnostics=1 pc.random_seed=15 ##restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed16
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed16
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed16 use_diagnostics=1 pc.random_seed=16 ##restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed16 use_diagnostics=1 pc.random_seed=16 ##restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed2
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed2
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed2 use_diagnostics=0 pc.random_seed=2 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed2 use_diagnostics=0 pc.random_seed=2 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed3
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed3
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed3 use_diagnostics=0 pc.random_seed=3 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed3 use_diagnostics=0 pc.random_seed=3 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed4
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed4
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed4 use_diagnostics=1 pc.random_seed=4 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed4 use_diagnostics=1 pc.random_seed=4 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed5
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed5
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed5 use_diagnostics=1 pc.random_seed=5 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed5 use_diagnostics=1 pc.random_seed=5 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed6
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed6
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed6 use_diagnostics=1 pc.random_seed=6 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed6 use_diagnostics=1 pc.random_seed=6 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed7
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed7
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed7 use_diagnostics=1 pc.random_seed=7 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed7 use_diagnostics=1 pc.random_seed=7 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed8
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed8
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed8 use_diagnostics=1 pc.random_seed=8 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed8 use_diagnostics=1 pc.random_seed=8 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed9
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rho1Dot6_2D/perl_rseed9
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed9 use_diagnostics=1 pc.random_seed=9 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rho1Dot6_2D/RandomSeed9 use_diagnostics=1 pc.random_seed=9 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed0 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed0 use_diagnostics=0 pc.random_seed=0 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed1
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed1
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed1 use_diagnostics=0 pc.random_seed=1 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed1 use_diagnostics=0 pc.random_seed=1 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed10
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed10
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed10 use_diagnostics=0 pc.random_seed=10 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed10 use_diagnostics=0 pc.random_seed=10 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed11
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed11
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed11 use_diagnostics=0 pc.random_seed=11 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed11 use_diagnostics=0 pc.random_seed=11 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed12
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed12
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed12 use_diagnostics=0 pc.random_seed=12 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed12 use_diagnostics=0 pc.random_seed=12 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed13
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed13
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed13 use_diagnostics=0 pc.random_seed=13 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed13 use_diagnostics=0 pc.random_seed=13 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed14
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed14
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed14 use_diagnostics=0 pc.random_seed=14 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed14 use_diagnostics=0 pc.random_seed=14 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed15
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed15
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed15 use_diagnostics=0 pc.random_seed=15 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed15 use_diagnostics=0 pc.random_seed=15 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed16
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed16
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed16 use_diagnostics=0 pc.random_seed=36 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed16 use_diagnostics=0 pc.random_seed=36 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed2
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed2
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed2 use_diagnostics=0 pc.random_seed=2 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed2 use_diagnostics=0 pc.random_seed=2 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed3
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed3
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed3 use_diagnostics=0 pc.random_seed=23 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed3 use_diagnostics=0 pc.random_seed=23 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed4
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed4
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed4 use_diagnostics=0 pc.random_seed=4 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed4 use_diagnostics=0 pc.random_seed=4 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed5
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed5
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed5 use_diagnostics=0 pc.random_seed=5 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed5 use_diagnostics=0 pc.random_seed=5 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed6
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed6
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed6 use_diagnostics=0 pc.random_seed=6 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed6 use_diagnostics=0 pc.random_seed=6 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed7
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed7
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed7 use_diagnostics=0 pc.random_seed=7 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed7 use_diagnostics=0 pc.random_seed=7 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed8
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed8
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed8 use_diagnostics=0 pc.random_seed=28 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed8 use_diagnostics=0 pc.random_seed=28 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed9
+++ b/perlmutter_scripts/pointCharge_topgate/randomSeed_variation/rhoDot7_3D/perl_rseed9
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed9 use_diagnostics=0 pc.random_seed=9 #restart=1 restart_step=7
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_3Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=0.7e27 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/rhoDot7_RandomSeed/RandomSeed9 use_diagnostics=0 pc.random_seed=9 #restart=1 restart_step=7

--- a/perlmutter_scripts/pointCharge_topgate/single_trap/Efm1/perl_1trap
+++ b/perlmutter_scripts/pointCharge_topgate/single_trap/Efm1/perl_1trap
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-1 pc.num=1 my_constants.Vgs_max=1.5 my_constants.Vgs_min=-2 my_constants.Nsteps=36 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/singleCharge/Efm1/Zoff4dz use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-1 pc.num=1 my_constants.Vgs_max=1.5 my_constants.Vgs_min=-2 my_constants.Nsteps=36 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/singleCharge/Efm1/Zoff4dz use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/single_trap/EfmDot2/perl_1trap
+++ b/perlmutter_scripts/pointCharge_topgate/single_trap/EfmDot2/perl_1trap
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 pc.num=1 my_constants.Vgs_max=1 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/singleCharge/EfmDot2/Zoff4dz use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 pc.num=1 my_constants.Vgs_max=1 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/singleCharge/EfmDot2/Zoff4dz use_diagnostics=1

--- a/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/1dot5nm/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/1dot5nm/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/1dot5nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+1.5e-9 pc.flag_write_individual_charge_files=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/1dot5nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+1.5e-9 pc.flag_write_individual_charge_files=1

--- a/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/1nm/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/1nm/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/1nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+1e-9 pc.flag_write_individual_charge_files=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/1nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+1e-9 pc.flag_write_individual_charge_files=1

--- a/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/2dot5nm/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/2dot5nm/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/2dot5nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+2.5e-9 pc.flag_write_individual_charge_files=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/2dot5nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+2.5e-9 pc.flag_write_individual_charge_files=1

--- a/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/2nm/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/2nm/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/2nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+2e-9 pc.flag_write_individual_charge_files=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/2nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+2e-9 pc.flag_write_individual_charge_files=1

--- a/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/3dot5nm/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/3dot5nm/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/3dot5nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+3.5e-9 pc.flag_write_individual_charge_files=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/3dot5nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+3.5e-9 pc.flag_write_individual_charge_files=1

--- a/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/3nm/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/3nm/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/3nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+3e-9 pc.flag_write_individual_charge_files=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/3nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+3e-9 pc.flag_write_individual_charge_files=1

--- a/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/4dot5nm/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/4dot5nm/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/4dot5nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+4.5e-9 pc.flag_write_individual_charge_files=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/4dot5nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+4.5e-9 pc.flag_write_individual_charge_files=1

--- a/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/4dot8nm/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/4dot8nm/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/ use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+4.8e-9 pc.flag_write_individual_charge_files=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/ use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+4.8e-9 pc.flag_write_individual_charge_files=1

--- a/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/4nm/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/4nm/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/4nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+4e-9 pc.flag_write_individual_charge_files=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/4nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+4e-9 pc.flag_write_individual_charge_files=1

--- a/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/dot5nm/perl_rseed0
+++ b/perlmutter_scripts/pointCharge_topgate/zPlaneVariation_2D/dot5nm/perl_rseed0
@@ -19,5 +19,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-#applications may performance better with --gpu-bind=none instead of --gpu-bind=single:1 
-srun -n 32 -c 32 --cpu_bind=cores -G 32 --gpu-bind=single:1  ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/dot5nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+5e-10 pc.flag_write_individual_charge_files=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_2Drand pc.Et=0.02 pc.V0=0.5 pc.mixing_factor=0.02 pc.charge_density=1.6e18 my_constants.Vgs_max=0.5 my_constants.Vgs_min=-1.6 my_constants.Nsteps=21 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/zPlaneVaried_alongHfO2Height_2Ddistrib/dot5nm use_diagnostics=1 pc.random_seed=0 my_constants.ZOffset=GO_bottom+5e-10 pc.flag_write_individual_charge_files=1


### PR DESCRIPTION
removing gpu binding in perlmutter scripts; code doesn't work unless you remove them