### PR TITLE
analysis scripts

### DIFF
--- a/perlmutter_scripts/pointCharge_topgate/no_trap/Efm1/perl_noCharge
+++ b/perlmutter_scripts/pointCharge_topgate/no_trap/Efm1/perl_noCharge
@@ -16,4 +16,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-1 pc.num=0 my_constants.Vgs_max=1.5 my_constants.Vgs_min=-2 my_constants.Nsteps=36 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/no_charge/Efm1 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-1 pc.num=0 my_constants.Vgs_max=1.5 my_constants.Vgs_min=-2 my_constants.Nsteps=36 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/no_charge/Efm1 use_diagnostics=1 plot.write_interval=1

--- a/perlmutter_scripts/pointCharge_topgate/no_trap/EfmDot2/perl_noCharge
+++ b/perlmutter_scripts/pointCharge_topgate/no_trap/EfmDot2/perl_noCharge
@@ -16,4 +16,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 pc.num=0 my_constants.Vgs_max=1 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/no_charge/EfmDot2 use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 pc.num=0 my_constants.Vgs_max=1 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/no_charge/EfmDot2 use_diagnostics=1 plot.write_interval=1

--- a/perlmutter_scripts/pointCharge_topgate/single_trap/Efm1/perl_1trap
+++ b/perlmutter_scripts/pointCharge_topgate/single_trap/Efm1/perl_1trap
@@ -16,4 +16,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-1 pc.num=1 my_constants.Vgs_max=1.5 my_constants.Vgs_min=-2 my_constants.Nsteps=36 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/singleCharge/Efm1/Zoff4dz use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-1 pc.num=1 my_constants.Vgs_max=1.5 my_constants.Vgs_min=-2 my_constants.Nsteps=36 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/singleCharge/Efm1/Zoff4dz use_diagnostics=1 plot.write_interval=1

--- a/perlmutter_scripts/pointCharge_topgate/single_trap/EfmDot2/perl_1trap
+++ b/perlmutter_scripts/pointCharge_topgate/single_trap/EfmDot2/perl_1trap
@@ -16,4 +16,4 @@ export OMP_PROC_BIND=spread
 
 
 #run the application:
-srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 pc.num=1 my_constants.Vgs_max=1 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/singleCharge/EfmDot2/Zoff4dz use_diagnostics=1
+srun -n 32 -c 32 --cpu_bind=cores -G 32 ../../../../Exec/main3d.gnu.MPI.CUDA.EB.TD.TRAN.BROYPRLL.HYPRE.ex ../../../../input/negf/point_charges/topgate_CNTFET_cluster my_constants.Ef=-0.2 pc.num=1 my_constants.Vgs_max=1 my_constants.Vgs_min=-2 my_constants.Nsteps=31 plot.folder_name=/global/cfs/projectdirs/m3766/ELEQTRONeX/point_charge/topgate_CNTFET/singleCharge/EfmDot2/Zoff4dz use_diagnostics=1 plot.write_interval=1

--- a/scripts/analysis/cnt_traps/scripts_for_paper/single_vs_no_trap/bandstructure.ipynb
+++ b/scripts/analysis/cnt_traps/scripts_for_paper/single_vs_no_trap/bandstructure.ipynb
@@ -145,10 +145,10 @@
     "foldername = [] \n",
     "variable_occupation = []\n",
     "\n",
-    "foldername.append('../simulations/no_charge/EfmDot2')\n",
+    "foldername.append('/global/cfs/projectdirs/m3766/ELEQTRONeX_old/point_charge/topgate_CNTFET/no_charge/EfmDot2')\n",
     "variable_occupation.append(False)\n",
     "\n",
-    "foldername.append('../simulations/singleCharge/EfmDot2/Zoff4dz')\n",
+    "foldername.append('/global/cfs/projectdirs/m3766/ELEQTRONeX_old/point_charge/topgate_CNTFET/singleCharge/EfmDot2/Zoff4dz')\n",
     "variable_occupation.append(True)\n",
     "\n",
     "# foldername.append('../simulations/Efm1/NoCharge')\n",
@@ -506,7 +506,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "NERSC Python",
    "language": "python",
    "name": "python3"
   },
@@ -520,7 +520,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/scripts/analysis/cnt_traps/scripts_for_paper/single_vs_no_trap/conductance.ipynb
+++ b/scripts/analysis/cnt_traps/scripts_for_paper/single_vs_no_trap/conductance.ipynb
@@ -159,7 +159,7 @@
     "Linestyle.append('solid')\n",
     "\n",
     "#simulations\n",
-    "foldername.append('../simulations/no_charge/EfmDot2')\n",
+    "foldername.append('/global/cfs/projectdirs/m3766/ELEQTRONeX_old/point_charge/topgate_CNTFET/no_charge/EfmDot2')\n",
     "label_str.append(r'0 trap, $E_F=$-0.2 eV')\n",
     "ZfromCNT.append('None')\n",
     "Markertype.append('None')\n",
@@ -168,7 +168,7 @@
     "Linestyle.append('dashed')\n",
     "\n",
     "\n",
-    "foldername.append('../simulations/singleCharge/EfmDot2/Zoff4dz')\n",
+    "foldername.append('/global/cfs/projectdirs/m3766/ELEQTRONeX_old/point_charge/topgate_CNTFET/singleCharge/EfmDot2/Zoff4dz')\n",
     "label_str.append(r'1 trap, $E_F=$-0.2 eV')\n",
     "ZfromCNT.append('0.3 nm')\n",
     "Color.append('k')\n",
@@ -177,7 +177,7 @@
     "Linestyle.append('dotted')\n",
     "\n",
     "\n",
-    "foldername.append('../simulations/no_charge/Efm1')\n",
+    "foldername.append('/global/cfs/projectdirs/m3766/ELEQTRONeX_old/point_charge/topgate_CNTFET/no_charge/Efm1')\n",
     "label_str.append(r'0 trap, $E_F=$-1 eV')\n",
     "ZfromCNT.append('None')\n",
     "Markertype.append('^')\n",
@@ -186,7 +186,7 @@
     "Linestyle.append('dashed')\n",
     "\n",
     "\n",
-    "foldername.append('../simulations/singleCharge/Efm1/Zoff4dz')\n",
+    "foldername.append('/global/cfs/projectdirs/m3766/ELEQTRONeX_old/point_charge/topgate_CNTFET/singleCharge/Efm1/Zoff4dz')\n",
     "label_str.append(r'1 trap, $E_F=$-1 eV')\n",
     "ZfromCNT.append('0.3 nm')\n",
     "Color.append('k')\n",
@@ -737,7 +737,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "NERSC Python",
    "language": "python",
    "name": "python3"
   },
@@ -751,7 +751,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
working on cleaning analysis scripts to "just work" when running on NERSC

You can now run

ELEQTRONeX/perlmutter_scripts/pointCharge_topgate/single_trap/Efm1/perl_1trap
ELEQTRONeX/perlmutter_scripts/pointCharge_topgate/single_trap/EfmDot2/perl_1trap
ELEQTRONeX/perlmutter_scripts/pointCharge_topgate/no_trap/Efm1/perl_noCharge
ELEQTRONeX/perlmutter_scripts/pointCharge_topgate/no_trap/EfmDot2/perl_noCharge

and then simply run

ELEQTRONeX/scripts/analysis/cnt_traps/scripts_for_paper/single_vs_no_trap/bandstructure.ipynb
ELEQTRONeX/scripts/analysis/cnt_traps/scripts_for_paper/single_vs_no_trap/conductance.ipynb

And now the scripts point to the data where it was actually generated.